### PR TITLE
Add roles and skills mapping

### DIFF
--- a/docs/roles-and-skills.md
+++ b/docs/roles-and-skills.md
@@ -1,0 +1,56 @@
+## Components and roles
+
+- **Mobile/Desktop Client**
+  - iOS Engineer (Swift/Obj-C)
+  - Android Engineer (Kotlin/Java)
+  - C++ Engineer (Cross-platform Core / TDLib)
+  - UI/UX Designer
+  - QA Engineer (Manual & Automation)
+
+- **MTProto Proxy/Load Balancer**
+  - Network Engineer
+  - C++ System Engineer
+  - Site Reliability Engineer (SRE)
+  - Security Engineer
+
+- **Auth Service**
+  - Backend Engineer (C++/Go)
+  - Security Engineer (Cryptography expert)
+  - QA Backend Engineer
+
+- **Message Database**
+  - Database Administrator (DBA)
+  - Backend Engineer (High-load systems)
+  - DevOps Engineer
+
+- **Media Storage / CDN**
+  - Infrastructure Engineer
+  - DevOps Engineer
+  - Backend Engineer
+
+## Roles and responsibilities
+
+1. **C++ Engineer (Core/Backend):**
+    Responsible for developing the high-performance core of the application (TDLib) and server-side logic. They optimize code for speed and efficiency, handle memory management, and implement the custom MTProto encryption protocol.
+
+2. **iOS/Android Engineer:**
+    Builds the user interface for mobile devices. They integrate the C++ core library into the mobile app, ensure smooth animations (60fps), and handle platform-specific features like notifications and file system access.
+
+3. **Site Reliability Engineer (SRE):**
+    Ensures that Telegram's servers are always up and running across global data centers. They manage monitoring systems, handle incident response (like server outages), and automate deployment processes.
+
+4. **Security Engineer:**
+    Audits the code for vulnerabilities, designs secure authentication flows, and tests the strength of the encryption protocols. They play a crucial role in maintaining user privacy and preventing data leaks.
+
+5. **QA Engineer (Quality Assurance):**
+    Tests the application for bugs before every release. They create test cases, run automated scripts to check core features (messaging, calls), and verify that the app works correctly on different devices and network conditions.
+
+## Common skills across roles
+
+Based on the analysis, the following technical skills are essential for most roles in this product team:
+
+- **Git:** Version control is mandatory for collaboration in any team.
+- **Linux/Terminal:** Basic command-line usage for deploying code or debugging logs.
+- **Understanding of Networking:** Knowledge of how data moves across the internet (HTTP, TCP/IP, DNS, Sockets).
+- **Algorithmic thinking:** Ability to solve complex problems and optimize performance.
+- **English:** Reading technical documentation and communicating in international teams.


### PR DESCRIPTION
## Summary
I created `docs/roles-and-skills.md` where I mapped Telegram components to IT roles, described responsibilities for 5 key roles (C++ Engineer, Mobile Engineer, SRE, Security Engineer, QA), and listed common technical skills.

- Closes #5 

## Checklist
- [x] I made this PR to the `main` branch **of my fork (NOT the original repo)**.
- [x] I linked at least one issue (`Closes #<issue-number>`).
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the code I’m submitting (not blindly copy-pasted).