### PR TITLE
Add markdown lint and link check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Markdown Lint
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: "**/*.md"
+
+      - name: Markdown Link Check
+        uses: tcort/github-action-markdown-link-check@v1


### PR DESCRIPTION
## Summary
I added a GitHub Actions workflow (`.github/workflows/ci.yml`) to automatically lint Markdown files and check for broken links on every push and pull request.

- Closes #10 

## Checklist
- [x] I made this PR to the `main` branch **of my fork (NOT the original repo)**.
- [x] I linked at least one issue (`Closes #<issue-number>`).
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the code I’m submitting (not blindly copy-pasted).